### PR TITLE
Add 'tv' and 'car' device types to module.json5

### DIFF
--- a/src-tauri/gen/ohos/entry/src/main/module.json5
+++ b/src-tauri/gen/ohos/entry/src/main/module.json5
@@ -7,7 +7,9 @@
     "deviceTypes": [
       "phone",
       "tablet",
-      "2in1"
+      "2in1",
+      "tv",
+      "car"
     ],
     "deliveryWithInstall": true,
     "installationFree": false,


### PR DESCRIPTION
New version contains Car & TV https://github.com/richerfu/tauri-demo/issues/13